### PR TITLE
Add Gradio LLM app for environmental stats

### DIFF
--- a/fourcastnet-nim/app.py
+++ b/fourcastnet-nim/app.py
@@ -1,0 +1,66 @@
+import gradio as gr
+from vllm import LLM, SamplingParams
+import point_stats
+
+# Lazy globals for dataset and model
+_DS = None
+_LLM = None
+_SAMPLING = SamplingParams(temperature=0.7, max_tokens=200)
+
+
+def _ensure_resources():
+    """Load forecast dataset and language model once."""
+    global _DS, _LLM
+    if _DS is None:
+        try:
+            _DS = point_stats._load_dataset()
+        except Exception as e:  # pragma: no cover
+            _DS = e
+    if _LLM is None:
+        try:
+            _LLM = LLM(model="gpt-oss-20b")
+        except Exception as e:  # pragma: no cover
+            _LLM = e
+
+
+_ensure_resources()
+
+
+def answer(lat, lon, question, when, interp):
+    """Generate a response about the environment at a location."""
+    if isinstance(_DS, Exception):
+        return f"Dataset load failed: {_DS}"
+    if isinstance(_LLM, Exception):
+        return f"Model load failed: {_LLM}"
+
+    when = when.strip() or None
+    if when:
+        df = point_stats.point_at_time(float(lat), float(lon), when, interp=interp, ds=_DS)
+    else:
+        df = point_stats.point_timeseries(float(lat), float(lon), ds=_DS)
+
+    stats = df.to_csv(index=False)
+    prompt = (
+        f"You are a helpful environmental assistant. Given the following forecast data for "
+        f"latitude {lat} and longitude {lon} from FourCastNet:\n{stats}\n"
+        f"Answer the user's question: {question}"
+    )
+    outputs = _LLM.generate([prompt], _SAMPLING)
+    return outputs[0].outputs[0].text.strip()
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Environment Q&A")
+    with gr.Row():
+        lat = gr.Number(label="Latitude", value=0.0)
+        lon = gr.Number(label="Longitude", value=0.0)
+    when = gr.Textbox(label="Time (ISO8601, optional)")
+    interp = gr.Dropdown(["nearest", "linear"], value="nearest", label="Interpolation")
+    q = gr.Textbox(label="Question")
+    ans = gr.Textbox(label="Answer")
+    btn = gr.Button("Ask")
+    btn.click(answer, inputs=[lat, lon, q, when, interp], outputs=ans)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    demo.launch()

--- a/fourcastnet-nim/client.Dockerfile
+++ b/fourcastnet-nim/client.Dockerfile
@@ -9,13 +9,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Python deps
 # earth2studio pulls xarray, numpy, etc.
 # If wheels change, pip may compile—build-essential covers that.
+# Core Python deps
 RUN pip install --no-cache-dir \
     numpy \
-    earth2studio
+    earth2studio \
+    gradio \
+    vllm
 
 # App code
 WORKDIR /app
-COPY make_input.py /app/make_input.py
+# Include utilities needed at runtime
+COPY make_input.py point_stats.py app.py /app/
 
 # Default command (overridden in script)
 CMD ["python", "/app/make_input.py", "/work/fcn_inputs.npy"]


### PR DESCRIPTION
## Summary
- Install gradio and vllm so the container can host an interactive UI
- Provide a new `app.py` with a Gradio interface backed by vLLM and `gpt-oss-20b` to answer location-based environment questions

## Testing
- `python -m py_compile make_input.py app.py point_stats.py`


------
https://chatgpt.com/codex/tasks/task_e_68c62a28d1008320b2ff03e0dfb434f3