### PR TITLE
Use CUDA base image for client runtime

### DIFF
--- a/fourcastnet-nim/client.Dockerfile
+++ b/fourcastnet-nim/client.Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build to install Python deps without internet access in runtime image
 # Stage 1: download wheels using internet-enabled base
-FROM python:3.11-slim AS builder
+FROM python:3.10-slim AS builder
 WORKDIR /wheelhouse
 COPY requirements.txt .
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -10,10 +10,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && pip download --dest /wheelhouse -r requirements.txt
 
 # Stage 2: runtime image that installs from local wheelhouse
-FROM python:3.11-slim
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
 WORKDIR /opt/nim
 COPY --from=builder /wheelhouse /wheelhouse
-RUN python -m venv /opt/nim/.venv \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-venv python3-pip ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv /opt/nim/.venv \
     && /opt/nim/.venv/bin/pip install --no-index --find-links=/wheelhouse -r /wheelhouse/requirements.txt
 COPY *.py /opt/nim/
 ENV PATH="/opt/nim/.venv/bin:$PATH"


### PR DESCRIPTION
## Summary
- Switch runtime stage to `nvidia/cuda:12.4.1-runtime-ubuntu22.04` and install Python via apt
- Align builder stage with Python 3.10 and install dependencies from local wheelhouse

## Testing
- `python -m py_compile app.py make_input.py point_stats.py`
- Attempted `pip install vllm==0.4.0` (fails: Could not find a version that satisfies the requirement vllm==0.4.0)

------
https://chatgpt.com/codex/tasks/task_e_68c638b4a6c48320b302c1efa433fe96