### PR TITLE
Add Python script to query FourCastNet NIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository bundles utilities for querying Earth-2 FourCastNet forecasts and
   - Variables: 2 m temperature (`t2m_C`), total column water vapor (`tcwv_kg_m2`), 10 m wind speed (`ws10m_m_s`), mean sea-level pressure (`msl_hPa`).
   - Supports 3×3 neighborhood summaries (mean/min/max) and arbitrary time requests using nearest or linear interpolation.
 - **`fourcastnet-nim/app.py`** – Gradio UI that uses `gpt-oss-20b` via vLLM to answer environmental questions for a given location.
+- **`fourcastnet-nim/query_nim.py`** – simple `requests`-based example for sending an input array to a local FourCastNet NIM and saving the forecast output.
 - **Offline-friendly Docker build** – dependencies are downloaded in a builder stage and installed from a local wheelhouse so the runtime image needs no internet access.
 
 ## Building
@@ -34,5 +35,5 @@ docker run --rm fourcastnet-client python point_stats.py --lat -33.93 --lon 18.4
 Ensure code changes compile:
 
 ```bash
-python -m py_compile fourcastnet-nim/make_input.py fourcastnet-nim/app.py fourcastnet-nim/point_stats.py
+python -m py_compile fourcastnet-nim/make_input.py fourcastnet-nim/app.py fourcastnet-nim/point_stats.py fourcastnet-nim/query_nim.py
 ```

--- a/fourcastnet-nim/query_nim.py
+++ b/fourcastnet-nim/query_nim.py
@@ -1,0 +1,35 @@
+import numpy as np
+import requests
+from datetime import datetime
+from earth2studio.data import ARCO
+from earth2studio.models.px.sfno import VARIABLES
+
+
+def main():
+    """Generate an input array and send it to a local FourCastNet NIM."""
+    ds = ARCO()
+    da = ds(time=datetime(2023, 1, 1), variable=VARIABLES)
+    input_array = da.to_numpy()[None].astype("float32")
+    np.save("fcn_inputs.npy", input_array)
+
+    resp = requests.get(
+        "http://localhost:8000/v1/health/ready",
+        headers={"accept": "application/json"},
+    )
+    resp.raise_for_status()
+
+    files = {
+        "input_array": open("fcn_inputs.npy", "rb"),
+        "input_time": (None, "2023-01-01T00:00:00Z"),
+        "simulation_length": (None, "4"),
+    }
+    resp = requests.post("http://localhost:8000/v1/infer", files=files)
+    resp.raise_for_status()
+
+    with open("output.tar", "wb") as f:
+        f.write(resp.content)
+    print("Output saved to output.tar")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document and add `query_nim.py`, a simple requests example for calling the FourCastNet NIM
- note the new script and update development instructions in the README

## Testing
- `python -m py_compile fourcastnet-nim/make_input.py fourcastnet-nim/app.py fourcastnet-nim/point_stats.py fourcastnet-nim/query_nim.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa02b06883209ea1c9d64dcfe2c5