### PR TITLE
Use official NIM image and streamline client dependencies

### DIFF
--- a/fourcastnet-nim/client.Dockerfile
+++ b/fourcastnet-nim/client.Dockerfile
@@ -1,23 +1,16 @@
-# Multi-stage build to install Python deps without internet access in runtime image
-# Stage 1: download wheels using internet-enabled base
-FROM python:3.10-slim AS builder
-WORKDIR /wheelhouse
-COPY requirements.txt .
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential curl git ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && python -m pip install --upgrade pip wheel \
-    && pip download --dest /wheelhouse -r requirements.txt
+# Base image: official FourCastNet NIM server
+FROM nvcr.io/nim/nvidia/fourcastnet:latest
 
-# Stage 2: runtime image that installs from local wheelhouse
-FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+# Work inside NIM directory
 WORKDIR /opt/nim
-COPY --from=builder /wheelhouse /wheelhouse
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-venv python3-pip ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && python3 -m venv /opt/nim/.venv \
-    && /opt/nim/.venv/bin/pip install --no-index --find-links=/wheelhouse -r /wheelhouse/requirements.txt
+
+# Install additional Python dependencies for client UI
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
 COPY *.py /opt/nim/
-ENV PATH="/opt/nim/.venv/bin:$PATH"
+
+# Default command launches the Gradio app
 CMD ["python", "/opt/nim/app.py"]

--- a/fourcastnet-nim/requirements.txt
+++ b/fourcastnet-nim/requirements.txt
@@ -1,4 +1,7 @@
+# Python dependencies for the FourCastNet demo client
 numpy==2.2.6
+pandas
+xarray
 earth2studio==0.8.1
 gradio==5.45.0
 vllm==0.10.2

--- a/fourcastnet-nim/run_fourcastnet.sh
+++ b/fourcastnet-nim/run_fourcastnet.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 NIM_IMAGE="nvcr.io/nim/nvidia/fourcastnet:latest"
 CLIENT_IMAGE="fourcastnet-client:latest"
 DATA_DIR="$(pwd)/data"
-PORT=8000
+PORT=8000          # host port for HTTP requests
+NIM_PORT=8003      # port exposed by the NIM container
 
 command -v docker >/dev/null 2>&1 || { echo "docker not found"; exit 1; }
 
@@ -22,9 +23,9 @@ mkdir -p "${DATA_DIR}"
 
 RUN_NAME="fourcastnet-nim"
 docker rm -f "${RUN_NAME}" >/dev/null 2>&1 || true
-docker run -d --name "${RUN_NAME}" \
-  --gpus all --shm-size 4g \
-  -p "${PORT}:8000" \
+docker run -d --rm --name "${RUN_NAME}" \
+  --runtime=nvidia --gpus all --shm-size 4g \
+  -p "${PORT}:${NIM_PORT}" \
   -e NGC_API_KEY \
   "${NIM_IMAGE}"
 


### PR DESCRIPTION
## Summary
- Base client Docker image on official `nvcr.io/nim/nvidia/fourcastnet:latest`
- Install Gradio and vLLM alongside other Python deps
- Align run script with official port mapping and NVIDIA runtime flags

## Testing
- `python -m py_compile fourcastnet-nim/*.py`
- `bash fourcastnet-nim/run_fourcastnet.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7036a87948320938b5b6fb14cbd90