### PR TITLE
fix: use python3 in client Dockerfile

### DIFF
--- a/fourcastnet-nim/client.Dockerfile
+++ b/fourcastnet-nim/client.Dockerfile
@@ -1,27 +1,15 @@
 # Base image: official FourCastNet NIM server
 FROM nvcr.io/nim/nvidia/fourcastnet:latest
 
-# Work inside NIM directory
-# Base image: official FourCastNet NIM server
-FROM nvcr.io/nim/nvidia/fourcastnet:latest
-
-# Work inside NIM directory
 WORKDIR /opt/nim
 
 # Install additional Python dependencies for client UI
 COPY requirements.txt ./
-RUN python -m pip install --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
-
-# Copy application code
-
-# Install additional Python dependencies for client UI
-COPY requirements.txt ./
-RUN python -m pip install --upgrade pip && \
+RUN python3 -m pip install --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
 COPY *.py /opt/nim/
 
 # Default command launches the Gradio app
-CMD ["python", "/opt/nim/app.py"]
+CMD ["python3", "/opt/nim/app.py"]


### PR DESCRIPTION
## Summary
- fix Dockerfile for FourCastNet client to use `python3` and clean duplication

## Testing
- `docker build -f client.Dockerfile .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c7098c5558832094cb991795a0afea