### PR TITLE
Fix dependencies and pip index for FourCastNet client

### DIFF
--- a/fourcastnet-nim/client.Dockerfile
+++ b/fourcastnet-nim/client.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/nim
 # Install additional Python dependencies for client UI
 COPY requirements.txt ./
 RUN python3 -m pip install --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt -i https://pypi.org/simple
 
 # Copy application code
 COPY *.py /opt/nim/

--- a/fourcastnet-nim/requirements.txt
+++ b/fourcastnet-nim/requirements.txt
@@ -1,5 +1,5 @@
 # Python dependencies for the FourCastNet demo client
-numpy==2.2.6
+numpy==2.0.2
 pandas
 xarray
 earth2studio==0.8.1


### PR DESCRIPTION
## Summary
- replace invalid numpy version with 2.0.2 in demo client requirements
- ensure Docker builds use public PyPI index to resolve dependencies

## Testing
- `python -m py_compile fourcastnet-nim/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c70a2236208320abb31f82ed3e3fde