### PR TITLE
Add docker-compose for FourCastNet client

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,23 @@ docker build -f fourcastnet-nim/client.Dockerfile -t fourcastnet-client fourcast
 ```
 
 ## Running
-All project scripts are placed in `/opt/nim` inside the image. To generate FourCastNet inputs or launch the Gradio app, mount any required data and run the container:
+You can run the client either with Docker Compose or by invoking the container directly.
+
+### Docker Compose
+1. Create a file at `fourcastnet-nim/.env` containing your NIM API key:
+
+   ```bash
+   echo "NIM_API_KEY=your_key_here" > fourcastnet-nim/.env
+   ```
+
+2. Launch the service (default port `8000` can be overridden via the `PORT` environment variable):
+
+   ```bash
+   docker compose up --build
+   ```
+
+### Manual Docker
+All project scripts are placed in `/opt/nim` inside the image. To generate FourCastNet inputs or launch the Gradio app without Docker Compose, mount any required data and run the container:
 
 ```bash
 docker run --rm -p 7860:7860 fourcastnet-client python app.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  fourcastnet:
+    build:
+      context: ./fourcastnet-nim
+      dockerfile: client.Dockerfile
+    image: fourcastnet-client:latest
+    env_file:
+      - ./fourcastnet-nim/.env
+    ports:
+      - "${PORT:-8000}:7860"
+    command: python app.py


### PR DESCRIPTION
## Summary
- add docker-compose file to build and run the FourCastNet client with environment variables
- document Docker Compose usage in README

## Testing
- `python -m py_compile fourcastnet-nim/make_input.py fourcastnet-nim/app.py fourcastnet-nim/point_stats.py fourcastnet-nim/query_nim.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c711a093a88320a20a18b587e0e2f2