### PR TITLE
Refactor FourCastNet utilities and clarify usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,99 @@
-# FourCastNet NIM Client
+# FourCastNet NIM Toolkit
 
-This repository bundles utilities for querying Earth-2 FourCastNet forecasts. All code lives in the `fourcastnet-nim` directory.
+Utilities for preparing inputs, querying an Earth-2 FourCastNet NIM, and post-processing the forecasts live in [`fourcastnet-nim/`](fourcastnet-nim/).
 
-## Features
+## Repository layout
 
-- **`fourcastnet-nim/point_stats.py`** – extract time-series forecasts at any latitude/longitude with optional neighborhood context and temporal interpolation.
-  - Variables: 2 m temperature (`t2m_C`), total column water vapor (`tcwv_kg_m2`), 10 m wind speed (`ws10m_m_s`), mean sea-level pressure (`msl_hPa`).
-  - Supports 3×3 neighborhood summaries (mean/min/max) and arbitrary time requests using nearest or linear interpolation.
-- **`fourcastnet-nim/query_nim.py`** – simple `requests`-based example for sending an input array to a local FourCastNet NIM and saving the forecast output.
-- **Manual-friendly Docker setup** – the image installs required system and Python packages and stays idle so you can run any script manually.
+| Path | Purpose |
+| --- | --- |
+| [`fourcastnet-nim/fcn_client.py`](fourcastnet-nim/fcn_client.py) | Shared helpers for creating input tensors and interacting with a running NIM instance. |
+| [`fourcastnet-nim/make_input.py`](fourcastnet-nim/make_input.py) | Command-line interface that writes the initial-condition tensor used by the NIM. |
+| [`fourcastnet-nim/query_nim.py`](fourcastnet-nim/query_nim.py) | CLI that submits a forecast request and stores the returned TAR archive. |
+| [`fourcastnet-nim/point_stats.py`](fourcastnet-nim/point_stats.py) | Extract a point time-series (with optional neighborhood stats) from the forecasted `.npy` files. |
+| [`fourcastnet-nim/requirements.txt`](fourcastnet-nim/requirements.txt) | Python dependencies needed for the utilities. |
+| [`fourcastnet-nim/Dockerfile`](fourcastnet-nim/Dockerfile) | Minimal image that installs the dependencies and exposes a shell for manual commands. |
+| [`docker-compose.yml`](docker-compose.yml) | Convenience wrapper to build/run the image locally. |
 
-## Building
-The `fourcastnet-nim/Dockerfile` installs all dependencies on top of a lightweight Python base image. Build it with:
+## Prerequisites
+
+* Python 3.10+
+* Access to the Earth-2 `earth2studio` data source (shipped in the requirements file)
+* A running FourCastNet NIM instance reachable from your machine
+* (Optional) Docker & Docker Compose if you prefer containerized workflows
+
+Install the Python requirements into your environment of choice:
+
+```bash
+pip install -r fourcastnet-nim/requirements.txt
+```
+
+## Quickstart workflow
+
+The utilities are designed to be run from the repository root using the system Python. Each step builds on the previous one.
+
+1. **Create the NIM input tensor**
+
+   ```bash
+   python fourcastnet-nim/make_input.py --time 2023-01-01T00:00:00Z --output inputs/fcn_inputs.npy
+   ```
+
+   This command samples the ARCO dataset for the requested analysis time and writes a batchified `(1, 73, 721, 1440)` tensor that FourCastNet expects.
+
+2. **Send the forecast request**
+
+   ```bash
+   python fourcastnet-nim/query_nim.py \
+       --base-url http://localhost:8000 \
+       --input inputs/fcn_inputs.npy \
+       --time 2023-01-01T00:00:00Z \
+       --steps 4 \
+       --output outputs/fcn_forecast.tar
+   ```
+
+   The script verifies that the `/v1/health/ready` endpoint is reachable, submits the request, and saves the returned TAR archive.
+
+3. **Extract the forecasted arrays**
+
+   FourCastNet returns its forecast as a TAR archive containing files named `000_000.npy`, `000_001.npy`, etc. Extract them into a working directory before running any diagnostics:
+
+   ```bash
+   mkdir -p outputs/fcn_forecast
+   tar -xvf outputs/fcn_forecast.tar -C outputs/fcn_forecast
+   cd outputs/fcn_forecast
+   ```
+
+4. **Compute point statistics**
+
+   With the `.npy` files available in the current directory, request a point time-series (e.g., Cape Town):
+
+   ```bash
+   python ../../fourcastnet-nim/point_stats.py --lat -33.93 --lon 18.42 --csv cape_town.csv
+   ```
+
+   By default the script calculates 2 m temperature, total column water vapor, 10 m wind, and mean sea-level pressure along with 3×3 neighborhood statistics. Use `--when <timestamp>` with `--interp linear` if you need a single time slice.
+
+## Running inside Docker
+
+The Docker image installs the Python dependencies and leaves you at a shell prompt.
 
 ```bash
 docker build -t fourcastnet-client fourcastnet-nim
+docker run --rm -it -v "$(pwd)":/workspace fourcastnet-client /bin/bash
 ```
 
-## Running
-You can run the client either with Docker Compose or by invoking the container directly.
-
-### Docker Compose
-1. Create a file at `fourcastnet-nim/.env` containing your NIM API key:
-
-   ```bash
-   echo "NIM_API_KEY=your_key_here" > fourcastnet-nim/.env
-   ```
-
-2. Build and start the container:
-
-   ```bash
-   docker compose up --build -d
-   ```
-
-3. Run whatever script you need inside the container, for example the point statistics utility:
-
-   ```bash
-   docker compose exec fourcastnet python point_stats.py --lat -33.93 --lon 18.42 --csv cape_town.csv
-   ```
-
-### Manual Docker
-All project scripts are placed in `/opt/nim` inside the image. To run the point statistics utility without Docker Compose, mount any required data and run the container:
+From inside the container, follow the quickstart steps (the project lives in `/workspace`). If you prefer Docker Compose, populate `fourcastnet-nim/.env` with your `NIM_API_KEY` and run:
 
 ```bash
-docker run --rm fourcastnet-client python point_stats.py --lat -33.93 --lon 18.42 --csv cape_town.csv
+docker compose up --build -d
+docker compose exec fourcastnet python query_nim.py --input fcn_inputs.npy
 ```
 
-## Development
-Ensure code changes compile:
+## Development checks
+
+Linting is not configured; however, Python's bytecode compiler helps catch syntax issues:
 
 ```bash
-python -m py_compile fourcastnet-nim/make_input.py fourcastnet-nim/point_stats.py fourcastnet-nim/query_nim.py
+python -m py_compile fourcastnet-nim/*.py
 ```
+
+Run this after modifying any scripts to ensure the project remains importable.

--- a/fourcastnet-nim/fcn_client.py
+++ b/fourcastnet-nim/fcn_client.py
@@ -1,0 +1,100 @@
+"""Shared utilities for building inputs and interacting with a FourCastNet NIM."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+import requests
+
+from earth2studio.data import ARCO
+from earth2studio.models.px.sfno import VARIABLES
+
+# FourCastNet expects 73 channels that match the VARIABLES ordering from earth2studio
+CHANNELS: Iterable[str] = tuple(VARIABLES)
+DEFAULT_INPUT_TIME = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+
+def generate_input_array(input_time: datetime = DEFAULT_INPUT_TIME) -> np.ndarray:
+    """Return a 73×721×1440 array wrapped in a batch dimension expected by the NIM."""
+    ds = ARCO()
+    da = ds(time=input_time, variable=VARIABLES)
+    array = da.to_numpy().astype("float32", copy=False)
+    if array.ndim != 3:
+        raise ValueError(
+            f"Expected a (variable, lat, lon) array from ARCO; received shape {array.shape}."
+        )
+    return array[None]
+
+
+def write_input_array(output_path: Path | str, input_time: datetime = DEFAULT_INPUT_TIME) -> Path:
+    """Generate an input array and persist it as ``.npy``."""
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    np.save(output, generate_input_array(input_time))
+    return output
+
+
+@dataclass(slots=True)
+class NimConfig:
+    """Connection information for a locally running FourCastNet NIM."""
+
+    base_url: str = "http://localhost:8000"
+    api_key: Optional[str] = None
+
+    def headers(self) -> dict[str, str]:
+        headers = {"accept": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+
+def health_ready(config: NimConfig) -> None:
+    """Raise ``HTTPError`` if the NIM is not ready."""
+    url = f"{config.base_url.rstrip('/')}/v1/health/ready"
+    resp = requests.get(url, headers=config.headers(), timeout=30)
+    resp.raise_for_status()
+
+
+def run_inference(
+    *,
+    config: NimConfig,
+    input_path: Path | str,
+    input_time: datetime,
+    simulation_length: int,
+    output_tar: Path | str,
+) -> Path:
+    """
+    Send a forecast request and save the TAR archive returned by the NIM.
+
+    Parameters
+    ----------
+    config:
+        Connection and authentication information.
+    input_path:
+        ``.npy`` file created by :func:`write_input_array`.
+    input_time:
+        ISO-8601 timestamp matching the contents of ``input_path``.
+    simulation_length:
+        Number of forecast steps (each step is 6 hours).
+    output_tar:
+        Path where the TAR response will be written.
+    """
+    health_ready(config)
+
+    url = f"{config.base_url.rstrip('/')}/v1/infer"
+    payload = {
+        "input_time": (None, input_time.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")),
+        "simulation_length": (None, str(simulation_length)),
+    }
+    with Path(input_path).open("rb") as f_in:
+        files = {"input_array": f_in, **payload}
+        resp = requests.post(url, headers=config.headers(), files=files, timeout=300)
+        resp.raise_for_status()
+
+    output_path = Path(output_tar)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(resp.content)
+    return output_path

--- a/fourcastnet-nim/make_input.py
+++ b/fourcastnet-nim/make_input.py
@@ -1,13 +1,42 @@
-import sys
+"""CLI helper that builds a FourCastNet input tensor from ARCO data."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
 from pathlib import Path
-import numpy as np
-from datetime import datetime
-from earth2studio.data import ARCO
-from earth2studio.models.px.sfno import VARIABLES
 
-out_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("fcn_inputs.npy")
-out_path.parent.mkdir(parents=True, exist_ok=True)
+from fcn_client import DEFAULT_INPUT_TIME, write_input_array
 
-ds = ARCO()
-da = ds(time=datetime(2023, 1, 1), variable=VARIABLES)
-np.save(out_path, da.to_numpy()[None].astype("float32"))
+
+def parse_time(value: str | None) -> datetime:
+    if value is None:
+        return DEFAULT_INPUT_TIME
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default="fcn_inputs.npy",
+        help="Path to the .npy file to create (default: fcn_inputs.npy)",
+    )
+    parser.add_argument(
+        "--time",
+        dest="input_time",
+        default=None,
+        help="ISO-8601 timestamp for the initial condition (default: 2023-01-01T00:00:00Z)",
+    )
+    args = parser.parse_args()
+
+    input_time = parse_time(args.input_time)
+    path = write_input_array(Path(args.output), input_time)
+    print(f"Saved FourCastNet input tensor to {path} for {input_time.isoformat()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fourcastnet-nim/point_stats.py
+++ b/fourcastnet-nim/point_stats.py
@@ -6,6 +6,8 @@ import pandas as pd
 from datetime import datetime, timedelta
 from typing import Tuple, Optional
 
+from fcn_client import CHANNELS
+
 # ---- CONFIG you can change ----
 INPUT_TIME_ISO = "2023-01-01T00:00:00Z"   # must match what you used in the /v1/infer call
 STEP_HOURS = 6                             # FourCastNet NIM uses 6h steps by default
@@ -28,7 +30,6 @@ def _load_dataset() -> xr.Dataset:
     times_py = [t0 + timedelta(hours=STEP_HOURS * i) for i in range(len(steps))]
     times = np.array([np.datetime64(int(t.timestamp()), "s") for t in times_py])
 
-    from earth2studio.models.px.sfno import VARIABLES
     lat, lon = _grid_lat_lon()
 
     norm_arrays = []
@@ -62,7 +63,7 @@ def _load_dataset() -> xr.Dataset:
 
     ds = xr.Dataset(
         {"fcn": (("time", "variable", "lat", "lon"), stack)},
-        coords={"time": times, "variable": VARIABLES, "lat": lat, "lon": lon},
+        coords={"time": times, "variable": CHANNELS, "lat": lat, "lon": lon},
         attrs={"description": "FourCastNet forecast"}
     )
     return ds

--- a/fourcastnet-nim/query_nim.py
+++ b/fourcastnet-nim/query_nim.py
@@ -1,34 +1,74 @@
-import numpy as np
-import requests
-from datetime import datetime
-from earth2studio.data import ARCO
-from earth2studio.models.px.sfno import VARIABLES
+"""Submit a forecast request to a locally running FourCastNet NIM."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fcn_client import DEFAULT_INPUT_TIME, NimConfig, run_inference
 
 
-def main():
-    """Generate an input array and send it to a local FourCastNet NIM."""
-    ds = ARCO()
-    da = ds(time=datetime(2023, 1, 1), variable=VARIABLES)
-    input_array = da.to_numpy()[None].astype("float32")
-    np.save("fcn_inputs.npy", input_array)
+def parse_time(value: str | None) -> datetime:
+    if value is None:
+        return DEFAULT_INPUT_TIME
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
-    resp = requests.get(
-        "http://localhost:8000/v1/health/ready",
-        headers={"accept": "application/json"},
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default="http://localhost:8000",
+        help="Base URL where the NIM is exposed (default: http://localhost:8000)",
     )
-    resp.raise_for_status()
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="Optional API key for authenticated deployments",
+    )
+    parser.add_argument(
+        "--input",
+        default="fcn_inputs.npy",
+        help="Path to the .npy file created via make_input.py (default: fcn_inputs.npy)",
+    )
+    parser.add_argument(
+        "--time",
+        dest="input_time",
+        default=None,
+        help="ISO-8601 timestamp matching the contents of --input",
+    )
+    parser.add_argument(
+        "--steps",
+        dest="simulation_length",
+        type=int,
+        default=4,
+        help="Number of 6-hour steps to request (default: 4)",
+    )
+    parser.add_argument(
+        "--output",
+        default="output.tar",
+        help="Where to store the TAR archive returned by the NIM (default: output.tar)",
+    )
+    args = parser.parse_args()
 
-    files = {
-        "input_array": open("fcn_inputs.npy", "rb"),
-        "input_time": (None, "2023-01-01T00:00:00Z"),
-        "simulation_length": (None, "4"),
-    }
-    resp = requests.post("http://localhost:8000/v1/infer", files=files)
-    resp.raise_for_status()
-
-    with open("output.tar", "wb") as f:
-        f.write(resp.content)
-    print("Output saved to output.tar")
+    config = NimConfig(base_url=args.base_url, api_key=args.api_key)
+    input_time = parse_time(args.input_time)
+    output = run_inference(
+        config=config,
+        input_path=Path(args.input),
+        input_time=input_time,
+        simulation_length=args.simulation_length,
+        output_tar=Path(args.output),
+    )
+    print(
+        "Saved forecast to",
+        output,
+        "for initial condition",
+        input_time.isoformat().replace("+00:00", "Z"),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a shared `fcn_client` helper module that handles input generation and inference calls
- refactor the make-input and query scripts into clear CLIs built on the shared helpers and update point stats to reuse the shared channel metadata
- rewrite the README with an explicit, step-by-step workflow covering input creation, inference, extraction, and diagnostics

## Testing
- python -m py_compile fourcastnet-nim/*.py

------
https://chatgpt.com/codex/tasks/task_e_68cb07546bb483208577493441e3a79e